### PR TITLE
feature/eo1-nodes-nf Aggregates node and edge count by year with running total

### DIFF
--- a/src/main/scala/org/citegraph/Application.scala
+++ b/src/main/scala/org/citegraph/Application.scala
@@ -36,6 +36,7 @@ object Application {
     // Validate and fix inputDirectory
     var inputDirectory: String = args(0)
     val outputDirectory: String = args(1)
+
     if (!isValidHdfsUri(inputDirectory)) {
       printf("Invalid HDFS input directory: %s\n", inputDirectory)
       System.exit(1)

--- a/src/main/scala/org/citegraph/analytics/Analytics.scala
+++ b/src/main/scala/org/citegraph/analytics/Analytics.scala
@@ -1,9 +1,69 @@
 package org.citegraph.analytics
 
-import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.expressions.Window
+import org.apache.spark.sql.functions.{col, sum}
 import org.apache.spark.sql.{DataFrame, Dataset, Row, SparkSession}
 
 class Analytics(sparkSession: SparkSession, citationsDF: DataFrame, publishedDatesDF: DataFrame) {
+
+  /**
+   * Calculate running totals of densities
+   */
+  def calculateRunningTotals(orderCol: String, sumCol: String, df: DataFrame): DataFrame = {
+    val previousRowsWindow = Window.orderBy(orderCol).rowsBetween(Window.unboundedPreceding, Window.currentRow)
+    df.withColumn(sumCol, sum(sumCol) over previousRowsWindow)
+  }
+
+  /**
+   * Use from IDs to join to publishedDatesDF and match edge counts to years
+   */
+  def getEdgeCountsByYear(df: DataFrame): DataFrame = {
+
+    /*
+    Get edge counts by year - group by year and count records with running total:
+      +----+------+
+      |year|  e(t)|
+      +----+------+
+      |1992|   170|
+      |1993|  2919|
+      |1994| 11568|
+      |... |...   |
+      +----+------+
+     */
+
+    publishedDatesDF
+      .join(df, publishedDatesDF("id") === df("from"))
+      .select("year", "count")
+      .groupBy("year")
+      .sum("count")
+      .sort(col("year"))
+      //      .withColumnRenamed("year", "edgeYear")
+      .withColumnRenamed("sum(count)", "e(t)")
+  }
+
+  /**
+   * Group by year, count and rename columns
+   */
+  def getNodeCountsByYear(): DataFrame = {
+
+    /*
+    Get node counts by year - group by year and count records with running total:
+      +----+-----+
+      |year| n(t)|
+      +----+-----+
+      |1993| 2852|
+      |1994| 5746|
+      |1995| 9190|
+      |... |...  |
+      +----+-----+
+     */
+
+    publishedDatesDF
+      .groupBy(col("year"))
+      .count()
+      .withColumnRenamed("count", "n(t)")
+      .withColumnRenamed("year", "nodeYear")
+  }
 
   /**
    * Finds the density of both nodes n(t) and edges e(t) for each year t.
@@ -11,20 +71,30 @@ class Analytics(sparkSession: SparkSession, citationsDF: DataFrame, publishedDat
   def findDensitiesByYear(): DataFrame = {
 
     /*
-    Find node density by year - group by year and count records:
-      +----+-----+
-      |year|count|
-      +----+-----+
-      |1997| 4252|
-      |1994| 2894|
-      |1996| 3939|
-      |... |...  |
-      +----+-----+
+    Find node and edge density by year - group by year and count records with running total:
+      +----+-----+------+
+      |year| n(t)|  e(t)|
+      +----+-----+------+
+      |1992|  855|   170|
+      |1993| 2852|  2919|
+      |1994| 5746| 11568|
+      |1995| 9190| 30161|
+      |... |...  |...   |
+      +----+-----+------+
      */
-    publishedDatesDF.groupBy(col("year"))
-      .count()
+
+    val edgeCountsDF = citationsDF.groupBy(col("from")).count()
+
+    val edgesByYearDF = getEdgeCountsByYear(edgeCountsDF)
+
+    val runningTotalEdgeCounts = calculateRunningTotals("year", "e(t)", edgesByYearDF)
+
+    val nodeCounts = getNodeCountsByYear()
+    val runningTotalNodeCounts = calculateRunningTotals("nodeYear", "n(t)", nodeCounts)
+
+    runningTotalNodeCounts
+      .join(runningTotalEdgeCounts, runningTotalNodeCounts("nodeYear") === runningTotalEdgeCounts("year"))
+      .select("year", "n(t)", "e(t)")
   }
-
-
 
 }

--- a/src/main/scala/org/citegraph/loading/DataFrameLoader.scala
+++ b/src/main/scala/org/citegraph/loading/DataFrameLoader.scala
@@ -31,6 +31,7 @@ class DataFrameLoader(val dataDirectory: String, val sparkSession: SparkSession)
       .filter(line => !line.contains("#") && line.trim().nonEmpty) // Remove lines that contain '#' and empty lines
       .map(line => {
         val lineParts: Array[String] = line.split("\\s+") // Split on whitespace
+        // Question: Does this remove lines with null values for from or to column?
         Row(lineParts(0).trim().toInt, lineParts(1).trim().toInt) // Output Row[Integer, Integer]
       })
 
@@ -58,6 +59,7 @@ class DataFrameLoader(val dataDirectory: String, val sparkSession: SparkSession)
       .filter(line => !line.contains("#") && line.trim().nonEmpty) // Remove lines that contain '#' and empty lines
       .map(line => {
         val lineParts: Array[String] = line.split("\\s+") // Split on whitespace
+        // Question: Could we use df.select(year('dt').alias('year')) to do this work?
         val year: Int = lineParts(1).trim().substring(0, 4).toInt // Only take first 4 digits of yyyy-mm-dd
 
         // For cross-listed papers, which have id 11<true_id>, just take the true id


### PR DESCRIPTION
I updated the node count code to aggregate each year count with all previous years to give us a running total, and I did the same for edge count. Let me know if you see anything that I may have missed or if you have suggestions on format/break up code more logically.